### PR TITLE
[51] - Bloquear páginas que necessitam de login

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -10,24 +10,44 @@ var app = angular.module('app', [
     'ngAnimate'
 ]);
 
-app.config(function ($routeProvider, $locationProvider) {
-    $routeProvider
-    .when('/', {
+window.routes = {
+    "/": {
         templateUrl: 'views/home.html',
-        controller: 'HomeCtrl'
-    })
-    .when('/login', {
+        controller: 'HomeCtrl',
+    },
+    "/login": {
         templateUrl: 'views/login.html',
-        controller: 'LoginCtrl'
-    })
-    .when('/cadastro', {
+        controller: 'LoginCtrl',
+        onlyGuest: true
+    },
+    "/cadastro": {
         templateUrl: 'views/register.html',
-        controller: 'RegisterCtrl'
-    })
-    .otherwise({
-        templateUrl: '404.html',
-        controller: 'ErrorCtrl'
-    }); 
+        controller: 'RegisterCtrl',
+        onlyGuest: true
+    }
+};
 
+app.config(function ($routeProvider, $locationProvider) {
+    for(var path in window.routes) {
+        $routeProvider.when(path, window.routes[path]);
+    }
+    $routeProvider.otherwise({redirectTo: '/404'});
     $locationProvider.html5Mode(true);
+});
+
+app.run(function($rootScope, $location, User, ENV) {
+    $rootScope.$on("$locationChangeStart", function(event, nextRoute) {
+        
+        nextRoute = nextRoute.replace(ENV.URL,"");
+
+        if(typeof window.routes[nextRoute] !== 'undefined') {
+            if(window.routes[nextRoute].onlyLogged && !User.isLogged()) {
+                event.preventDefault();
+                $location.path('/login');
+            } else if(window.routes[nextRoute].onlyGuest && User.isLogged()) {
+                event.preventDefault();
+                $location.path('/');
+            }
+        }
+    });
 });

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -38,7 +38,7 @@ app.config(function ($routeProvider, $locationProvider) {
 app.run(function($rootScope, $location, User, ENV) {
     $rootScope.$on("$locationChangeStart", function(event, nextRoute) {
         
-        nextRoute = nextRoute.replace(ENV.URL,"");
+        nextRoute = nextRoute.replace(ENV.BASE_URL,"");
 
         if(typeof window.routes[nextRoute] !== 'undefined') {
             if(window.routes[nextRoute].onlyLogged && !User.isLogged()) {

--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -1,14 +1,9 @@
-app.controller('LoginCtrl', function ($scope, $http, $localStorage, $location, ENV) {
-    if($localStorage.token){
-        $location.path('/');
-        return;
-    }
-    
+app.controller('LoginCtrl', function ($scope, $http, $location, ENV, User) {
     $scope.user = {};
 
     $scope.login = function() {
         $http.post(ENV.API.LOGIN, $scope.user).then(function(response) {
-            $localStorage.token = response.data.token;
+            User.loggedIn(response.data.token);
             $location.path('/');
         }, function(response) {
             if(response.data) {
@@ -25,7 +20,12 @@ app.controller('LoginCtrl', function ($scope, $http, $localStorage, $location, E
                     $('#password').focus();
                 }
             }
-            
         });
+    };
+
+    $scope.logout = function() {
+        User.loggedOut();
+        $location.path('/');
+        location.reload();
     };
 });

--- a/app/scripts/controllers/page.js
+++ b/app/scripts/controllers/page.js
@@ -1,13 +1,2 @@
-app.controller('PageCtrl', function ($scope, $localStorage, $location) {
-    $scope.isLogged = false;
-
-	if($localStorage.token){
-        $scope.isLogged = true;
-    }
-    
-    $scope.logout = function() {
-        delete $localStorage.token;
-        $location.path('/');
-        location.reload();
-    };
+app.controller('PageCtrl', function () {    
 });

--- a/app/scripts/controllers/register.js
+++ b/app/scripts/controllers/register.js
@@ -1,9 +1,4 @@
 app.controller('RegisterCtrl', function ($scope, $http, $location, ENV, messagesContainer, User) {
-	if(User.isLogged()){
-        $location.path('/');
-        return;
-    }
-    
 	$scope.user = {};
 
 	$scope.emailValidator = function(email){

--- a/app/scripts/controllers/register.js
+++ b/app/scripts/controllers/register.js
@@ -1,5 +1,5 @@
-app.controller('RegisterCtrl', function ($scope, $http, $localStorage, $location, ENV, messagesContainer) {
-	if($localStorage.token){
+app.controller('RegisterCtrl', function ($scope, $http, $location, ENV, messagesContainer, User) {
+	if(User.isLogged()){
         $location.path('/');
         return;
     }
@@ -16,9 +16,9 @@ app.controller('RegisterCtrl', function ($scope, $http, $localStorage, $location
 
 	$scope.register = function() {
 	    $http.post(ENV.API.REGISTER, $scope.user).then(function(response) {
-	        $localStorage.token = response.data.token;
-            $location.path('/');
+	    	User.loggedIn(response.data.token);
             messagesContainer.addSuccess("Bem-vindo ao QualFacul!");
+            $location.path('/');
 	    }, function(response) {
 	    	if(response.data) {
 	    		$scope.error = {};

--- a/app/scripts/directives/page.html
+++ b/app/scripts/directives/page.html
@@ -31,7 +31,7 @@
                             <ul class="dropdown-menu">
                                 <li><a href="/configuracoes" class="config">Configurações</a></li>
                                 <li><a href="/perfil" class="profile">Meu perfil</a></li>
-                                <li><a href="#" class="logout" ng-click="logout();">Sair</a></li>
+                                <li><a href="#" class="logout" ng-click="logout();" ng-controller="LoginCtrl">Sair</a></li>
                             </ul>
                         </li>
                     </ul>                

--- a/app/scripts/interceptor.js
+++ b/app/scripts/interceptor.js
@@ -1,22 +1,21 @@
-app.factory('AuthInterceptor', ['$q', '$location', '$localStorage', function ($q, $location, $localStorage) {
-    return {
-        request: function(config) {
-            config.headers = config.headers || {};
-            if ($localStorage.token) {
-                config.headers.Authorization = $localStorage.token;
-            }
-            return config;
-        },
-        responseError: function(response) {
-            if (response.status === 401) {
-                delete $localStorage.token;
-                $location.path('/login');
-            }
-            return $q.reject(response);
-        }
-    };	
-}]);
-
 app.config(['$httpProvider', function ($httpProvider) {
-    $httpProvider.interceptors.push('AuthInterceptor');
+    $httpProvider.interceptors.push(function($q, $location, User) {
+        return {
+            request: function(config) {
+                config.headers = config.headers || {};
+                if(User.isLogged()){ 
+                    config.headers.Authorization = User.getToken();
+                }
+                return config;
+            },
+            responseError: function(response) {
+                if (response.status === 401) {
+                    User.loggedOut();
+                    $location.path('/login');
+                }
+                return $q.reject(response);
+            }
+        };      
+    });
+    
 }]);

--- a/app/scripts/properties.js.sample
+++ b/app/scripts/properties.js.sample
@@ -6,7 +6,9 @@ app.constant('ENV', (function() {
       LOGIN: api + '/login',
       REGISTER: api + '/register',
       HOME: api + '/home',
-    }
+    },
+
+    URL: 'http://localhost:9000'
   }
 
 }()));

--- a/app/scripts/properties.js.sample
+++ b/app/scripts/properties.js.sample
@@ -8,7 +8,7 @@ app.constant('ENV', (function() {
       HOME: api + '/home',
     },
 
-    URL: 'http://localhost:9000'
+    BASE_URL: 'http://localhost:9000'
   }
 
 }()));

--- a/app/scripts/services/user.js
+++ b/app/scripts/services/user.js
@@ -1,0 +1,22 @@
+app.service('User', function($localStorage, $rootScope) {
+
+	this.loggedIn = function(token) {
+		$localStorage.token = token;
+		$rootScope.isLogged = true;
+	};
+
+	this.loggedOut = function() {
+		delete $localStorage.token;
+		$rootScope.isLogged = false;
+	};
+
+	this.isLogged = function() {
+		return ($localStorage.token);
+	};
+
+	this.getToken = function() {
+		return $localStorage.token;
+	};
+
+	$rootScope.isLogged = this.isLogged();
+});


### PR DESCRIPTION
ℹ️  Para bloquear rotas,  no `app.js` na variavel `window.routes` 
- adicionar a propriedade `onlyLogged:true` para permitir somente usuários logados
- adicionar a propriedade `onlyGuest:true` para permitir somente usuários NÃO logados 
- páginas que permitem qualquer tipo de usuário, logado ou deslogado, continuam iguais, não precisam de nenhuma das duas propriedades.

ℹ️  Gerenciando o token
Foi adicionado o service `User` que controla as ações de login e logout, gerenciando o token através das funções

**TO TEST**
- [ ] Testar os fluxos que mexem diretamente com o token 
- [ ] Todas as funções que gerenciam o token, devem o fazer através do service `User` e não diretamente com o `$localStorage`
- [ ] Criar uma rota e bloquear a url para usuários não logados
- [ ] Criar uma rota e bloquear a url para usuários logados
- [ ] Criar uma rota que permita todos usuários
